### PR TITLE
Use "model" not "version" as the noun

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ To run a prediction and return its output:
 import replicate from "replicate";
 
 const prediction = await replicate
-  .version("db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf")
+  .model(
+    "stability-ai/stable-diffusion@db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf"
+  )
   .predict({
     prompt: "painting of a cat by andy warhol",
   });
@@ -38,7 +40,9 @@ running, you can pass in an `onUpdate` callback function:
 import replicate from "replicate";
 
 await replicate
-  .version("db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf")
+  .model(
+    "stability-ai/stable-diffusion@db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf"
+  )
   .predict(
     {
       prompt: "painting of a cat by andy warhol",
@@ -58,7 +62,9 @@ If you'd prefer to control your own polling you can use the low-level
 import replicate from "replicate";
 
 const prediction = await replicate
-  .version("db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf")
+  .model(
+    "stability-ai/stable-diffusion@db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf"
+  )
   .createPrediction({
     prompt: "painting of a cat by andy warhol",
   });

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -4,27 +4,36 @@ import ReplicateObject from "./ReplicateObject.js";
 import { sleep } from "./utils.js";
 
 export default class Model extends ReplicateObject {
-  constructor({ owner, name, version, id, ...rest }, client) {
+  static propertyMap = {
+    id: "version",
+  };
+
+  constructor({ owner, name, version, ...rest }, client) {
     super(rest, client);
 
-    if (!owner) {
+    if (owner) {
+      this.owner = owner;
+    }
+
+    if (!this.owner) {
       throw new ReplicateError("owner is required");
     }
 
-    this.owner = owner;
+    if (name) {
+      this.name = name;
+    }
 
-    if (!name) {
+    if (!this.name) {
       throw new ReplicateError("name is required");
     }
 
-    this.name = name;
-
-    if (!(version || id)) {
-      throw new ReplicateError("version is required");
+    if (version) {
+      this.version = version;
     }
 
-    // We get `id` back from the API, but we want to call it `version` here.
-    this.version = version || id;
+    if (!this.version) {
+      throw new ReplicateError("version is required");
+    }
   }
 
   actionForGet() {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -3,15 +3,32 @@ import Prediction from "./Prediction.js";
 import ReplicateObject from "./ReplicateObject.js";
 import { sleep } from "./utils.js";
 
-export default class Version extends ReplicateObject {
-  constructor({ id, ...rest }, client) {
+export default class Model extends ReplicateObject {
+  constructor({ owner, name, version, id, ...rest }, client) {
     super(rest, client);
 
-    if (!id) {
-      throw new ReplicateError("id is required");
+    if (!owner) {
+      throw new ReplicateError("owner is required");
     }
 
-    this.id = id;
+    this.owner = owner;
+
+    if (!name) {
+      throw new ReplicateError("name is required");
+    }
+
+    this.name = name;
+
+    if (!(version || id)) {
+      throw new ReplicateError("version is required");
+    }
+
+    // We get `id` back from the API, but we want to call it `version` here.
+    this.version = version || id;
+  }
+
+  actionForGet() {
+    return `GET /v1/models/${this.owner}/${this.name}/versions/${this.version}`;
   }
 
   async predict(
@@ -68,11 +85,12 @@ export default class Version extends ReplicateObject {
 
   async createPrediction(input) {
     // This is here and not on `Prediction` because conceptually, a prediction
-    // from a version "belongs" to the version. It's an odd feature of the API
-    // that the prediction creation isn't an action on the version, but we don't
-    // need to expose that to users of this library.
+    // from a model "belongs" to the model. It's an odd feature of the API that
+    // the prediction creation isn't an action on the model (or that it doesn't
+    // actually use the model information, only the version), but we don't need
+    // to expose that to users of this library.
     const predictionData = await this.client.request("POST /v1/predictions", {
-      version: this.id,
+      version: this.version,
       input,
     });
 

--- a/lib/Model.test.js
+++ b/lib/Model.test.js
@@ -22,6 +22,19 @@ beforeEach(() => {
   model = client.model("test-owner/test-name@testversion");
 });
 
+describe("constructor()", () => {
+  it("maps id to version", () => {
+    const model = new Model({
+      owner: "test-owner",
+      name: "test-name",
+      id: "testversion",
+    });
+
+    expect(model.id).toBeUndefined();
+    expect(model.version).toBe("testversion");
+  });
+});
+
 describe("load()", () => {
   it("makes request to get model version", async () => {
     jest.spyOn(client, "request").mockResolvedValue({

--- a/lib/Model.test.js
+++ b/lib/Model.test.js
@@ -7,48 +7,83 @@ jest.unstable_mockModule("node-fetch", () => ({
 }));
 
 import { ReplicateResponseError } from "./errors.js";
+import Model from "./Model.js";
 import Prediction, { PredictionStatus } from "./Prediction.js";
 
 const { default: ReplicateClient } = await import("./ReplicateClient.js");
 
 let client;
-let version;
+let model;
 
 beforeEach(() => {
   process.env.REPLICATE_API_TOKEN = "test-token-from-env";
 
   client = new ReplicateClient({});
-  version = client.version("test-version");
+  model = client.model("test-owner/test-name@testversion");
+});
+
+describe("load()", () => {
+  it("makes request to get model version", async () => {
+    jest.spyOn(client, "request").mockResolvedValue({
+      id: "testversion",
+    });
+
+    await model.load();
+
+    expect(client.request).toHaveBeenCalledWith(
+      "GET /v1/models/test-owner/test-name/versions/testversion"
+    );
+  });
+
+  it("returns Model", async () => {
+    jest.spyOn(client, "request").mockResolvedValue({
+      id: "testversion",
+    });
+
+    const returnedModel = await model.load();
+
+    expect(returnedModel).toBeInstanceOf(Model);
+  });
+
+  it("updates Model in place", async () => {
+    jest.spyOn(client, "request").mockResolvedValue({
+      id: "testversion",
+    });
+
+    const returnedModel = await model.load();
+
+    expect(returnedModel).toBe(model);
+  });
 });
 
 describe("predict()", () => {
   it("makes request to create prediction", async () => {
-    jest.spyOn(version, "createPrediction").mockResolvedValue(
+    jest.spyOn(model, "createPrediction").mockResolvedValue(
       new Prediction(
         {
-          id: "test-prediction",
+          id: "testprediction",
           status: PredictionStatus.SUCCEEDED,
         },
         client
       )
     );
 
-    await version.predict(
+    await model.predict(
       { text: "test text" },
       {},
       { defaultPollingInterval: 0 }
     );
 
-    expect(version.createPrediction).toHaveBeenCalledWith({
+    expect(model.createPrediction).toHaveBeenCalledWith({
       text: "test text",
     });
   });
 
   it("uses created prediction's ID to fetch update", async () => {
-    jest.spyOn(version, "createPrediction").mockResolvedValue(
+    jest.spyOn(model, "createPrediction").mockResolvedValue(
       new Prediction(
         {
-          id: "test-prediction",
+          id: "testprediction",
           status: PredictionStatus.STARTING,
         },
         client
@@ -75,20 +110,20 @@ describe("predict()", () => {
       .spyOn(client, "request")
       .mockImplementation((action) => requestMockReturnValues[action]);
 
-    await version.predict(
+    await model.predict(
       { text: "test text" },
       {},
       { defaultPollingInterval: 0 }
     );
 
-    expect(client.prediction).toHaveBeenCalledWith("test-prediction");
+    expect(client.prediction).toHaveBeenCalledWith("testprediction");
   });
 
   it("polls prediction status until success", async () => {
-    jest.spyOn(version, "createPrediction").mockResolvedValue(
+    jest.spyOn(model, "createPrediction").mockResolvedValue(
       new Prediction(
         {
-          id: "test-prediction",
+          id: "testprediction",
           status: PredictionStatus.STARTING,
         },
         client
@@ -98,21 +133,21 @@ describe("predict()", () => {
     const predictionLoadResults = [
       new Prediction(
         {
-          id: "test-prediction",
+          id: "testprediction",
           status: PredictionStatus.PROCESSING,
         },
         client
       ),
       new Prediction(
         {
-          id: "test-prediction",
+          id: "testprediction",
           status: PredictionStatus.PROCESSING,
         },
         client
       ),
       new Prediction(
         {
-          id: "test-prediction",
+          id: "testprediction",
           status: PredictionStatus.SUCCEEDED,
         },
         client
@@ -122,14 +157,14 @@ describe("predict()", () => {
     const predictionLoad = jest.fn(() => predictionLoadResults.shift());
 
     jest.spyOn(client, "prediction").mockImplementation(() => {
-      const prediction = new Prediction({ id: "test-prediction" }, client);
+      const prediction = new Prediction({ id: "testprediction" }, client);
 
       jest.spyOn(prediction, "load").mockImplementation(predictionLoad);
 
       return prediction;
     });
 
-    const prediction = await version.predict(
+    const prediction = await model.predict(
       { text: "test text" },
       {},
       { defaultPollingInterval: 0 }
@@ -140,10 +175,10 @@ describe("predict()", () => {
   });
 
   it("retries polling on error", async () => {
-    jest.spyOn(version, "createPrediction").mockResolvedValue(
+    jest.spyOn(model, "createPrediction").mockResolvedValue(
       new Prediction(
         {
-          id: "test-prediction",
+          id: "testprediction",
           status: PredictionStatus.STARTING,
         },
         client
@@ -172,7 +207,7 @@ describe("predict()", () => {
       () =>
         new Prediction(
           {
-            id: "test-prediction",
+            id: "testprediction",
             status: PredictionStatus.SUCCEEDED,
           },
           client
@@ -182,7 +217,7 @@ describe("predict()", () => {
     const predictionLoad = jest.fn(() => predictionLoadResults.shift()());
 
     jest.spyOn(client, "prediction").mockImplementation(() => {
-      const prediction = new Prediction({ id: "test-prediction" }, client);
+      const prediction = new Prediction({ id: "testprediction" }, client);
 
       jest.spyOn(prediction, "load").mockImplementation(predictionLoad);
 
@@ -190,7 +225,7 @@ describe("predict()", () => {
     });
     const backoffFn = jest.fn(() => 0);
 
-    const prediction = await version.predict(
+    const prediction = await model.predict(
       { text: "test text" },
       {},
       { defaultPollingInterval: 0, backoffFn }
@@ -205,14 +240,14 @@ describe("predict()", () => {
 describe("createPrediction()", () => {
   it("makes request to create prediction", async () => {
     jest.spyOn(client, "request").mockResolvedValue({
-      id: "test-prediction",
+      id: "testprediction",
       status: PredictionStatus.SUCCEEDED,
     });
 
-    await version.createPrediction({ text: "test text" });
+    await model.createPrediction({ text: "test text" });
 
     expect(client.request).toHaveBeenCalledWith("POST /v1/predictions", {
-      version: "test-version",
+      version: "testversion",
       input: { text: "test text" },
     });
   });

--- a/lib/Prediction.js
+++ b/lib/Prediction.js
@@ -13,11 +13,13 @@ export default class Prediction extends ReplicateObject {
   constructor({ id, ...rest }, client) {
     super(rest, client);
 
-    if (!id) {
-      throw new ReplicateError("id is required");
+    if (id) {
+      this.id = id;
     }
 
-    this.id = id;
+    if (!this.id) {
+      throw new ReplicateError("id is required");
+    }
   }
 
   actionForGet() {

--- a/lib/Prediction.test.js
+++ b/lib/Prediction.test.js
@@ -16,26 +16,26 @@ beforeEach(() => {
   process.env.REPLICATE_API_TOKEN = "test-token-from-env";
 
   client = new ReplicateClient({});
-  prediction = client.prediction("test-prediction");
+  prediction = client.prediction("testprediction");
 });
 
 describe("load()", () => {
   it("makes request to get prediction", async () => {
     jest.spyOn(client, "request").mockResolvedValue({
-      id: "test-prediction",
+      id: "testprediction",
       status: PredictionStatus.SUCCEEDED,
     });
 
     await prediction.load();
 
     expect(client.request).toHaveBeenCalledWith(
-      "GET /v1/predictions/test-prediction"
+      "GET /v1/predictions/testprediction"
     );
   });
 
-  it("returns a Prediction", async () => {
+  it("returns Prediction", async () => {
     jest.spyOn(client, "request").mockResolvedValue({
-      id: "test-prediction",
+      id: "testprediction",
       status: PredictionStatus.SUCCEEDED,
     });
 
@@ -46,7 +46,7 @@ describe("load()", () => {
 
   it("updates the prediction in place", async () => {
     jest.spyOn(client, "request").mockResolvedValue({
-      id: "test-prediction",
+      id: "testprediction",
       status: PredictionStatus.SUCCEEDED,
     });
 

--- a/lib/Prediction.test.js
+++ b/lib/Prediction.test.js
@@ -44,7 +44,7 @@ describe("load()", () => {
     expect(returnedPrediction).toBeInstanceOf(Prediction);
   });
 
-  it("updates the prediction in place", async () => {
+  it("updates Prediction in place", async () => {
     jest.spyOn(client, "request").mockResolvedValue({
       id: "testprediction",
       status: PredictionStatus.SUCCEEDED,

--- a/lib/ReplicateClient.js
+++ b/lib/ReplicateClient.js
@@ -21,6 +21,39 @@ export default class ReplicateClient {
     }
   }
 
+  async getModelVersions(nameOrParams) {
+    let owner, name;
+
+    if (typeof nameOrParams === "string") {
+      const nameComponents = /^([\w-]+)\/([\w-]+)$/.exec(nameOrParams);
+
+      if (!nameComponents) {
+        throw new ReplicateError(`Invalid name: ${nameOrParams}`);
+      }
+
+      [, owner, name] = nameComponents;
+    } else if (nameOrParams.owner) {
+      owner = nameOrParams.owner;
+      name = nameOrParams.name;
+    } else {
+      const nameComponents = /^([\w-]+)\/([\w-]+)$/.exec(nameOrParams.name);
+
+      if (!nameComponents) {
+        throw new ReplicateError(`Invalid name: ${nameOrParams.name}`);
+      }
+
+      [, owner, name] = nameComponents;
+    }
+
+    const versions = await this.request(
+      `GET /v1/models/${owner}/${name}/versions`
+    );
+
+    return versions.map(
+      (version) => new Model({ owner, name, ...version }, this)
+    );
+  }
+
   model(idOrParams) {
     let owner, name, version;
 

--- a/lib/ReplicateClient.js
+++ b/lib/ReplicateClient.js
@@ -28,7 +28,9 @@ export default class ReplicateClient {
       const nameComponents = /^([\w-]+)\/([\w-]+)$/.exec(nameOrParams);
 
       if (!nameComponents) {
-        throw new ReplicateError(`Invalid name: ${nameOrParams}`);
+        throw new ReplicateError(
+          `Invalid model name: ${nameOrParams}. This should be a string in the format {owner}/{name} or an object with owner and name strings.`
+        );
       }
 
       [, owner, name] = nameComponents;
@@ -39,7 +41,9 @@ export default class ReplicateClient {
       const nameComponents = /^([\w-]+)\/([\w-]+)$/.exec(nameOrParams.name);
 
       if (!nameComponents) {
-        throw new ReplicateError(`Invalid name: ${nameOrParams.name}`);
+        throw new ReplicateError(
+          `Invalid model name: ${nameOrParams}. This should be a string in the format {owner}/{name} or specify both owner and name strings in the parameter object.`
+        );
       }
 
       [, owner, name] = nameComponents;
@@ -61,7 +65,9 @@ export default class ReplicateClient {
       const idComponents = /^([\w-]+)\/([\w-]+)@(\w+)$/.exec(idOrParams);
 
       if (!idComponents) {
-        throw new ReplicateError(`Invalid ID: ${idOrParams}`);
+        throw new ReplicateError(
+          `Invalid model ID: ${idOrParams}. This should be a string in the format {owner}/{name}@{version} or an object with owner, name, and version strings.`
+        );
       }
 
       [, owner, name, version] = idComponents;
@@ -73,7 +79,9 @@ export default class ReplicateClient {
         const nameComponents = /^([\w-]+)\/([\w-]+)$/.exec(idOrParams.name);
 
         if (!nameComponents) {
-          throw new ReplicateError(`Invalid name: ${idOrParams.name}`);
+          throw new ReplicateError(
+            `Invalid model name: ${idOrParams.name}. This should be a string in the format {owner}/{name} or specify both owner and name strings in the parameter object.`
+          );
         }
 
         [, owner, name] = nameComponents;

--- a/lib/ReplicateClient.js
+++ b/lib/ReplicateClient.js
@@ -21,14 +21,33 @@ export default class ReplicateClient {
     }
   }
 
-  model(fullId) {
-    const idComponents = /^([\w-]+)\/([\w-]+)@(\w+)$/.exec(fullId);
+  model(idOrParams) {
+    let owner, name, version;
 
-    if (!idComponents) {
-      throw new ReplicateError(`Invalid ID: ${fullId}`);
+    if (typeof idOrParams === "string") {
+      const idComponents = /^([\w-]+)\/([\w-]+)@(\w+)$/.exec(idOrParams);
+
+      if (!idComponents) {
+        throw new ReplicateError(`Invalid ID: ${idOrParams}`);
+      }
+
+      [, owner, name, version] = idComponents;
+    } else {
+      if (idOrParams.owner) {
+        owner = idOrParams.owner;
+        name = idOrParams.name;
+      } else {
+        const nameComponents = /^([\w-]+)\/([\w-]+)$/.exec(idOrParams.name);
+
+        if (!nameComponents) {
+          throw new ReplicateError(`Invalid name: ${idOrParams.name}`);
+        }
+
+        [, owner, name] = nameComponents;
+      }
+
+      version = idOrParams.version;
     }
-
-    const [, owner, name, version] = idComponents;
 
     return new Model({ owner, name, version }, this);
   }

--- a/lib/ReplicateClient.js
+++ b/lib/ReplicateClient.js
@@ -5,8 +5,8 @@ import {
   ReplicateRequestError,
   ReplicateResponseError,
 } from "./errors.js";
+import Model from "./Model.js";
 import Prediction from "./Prediction.js";
-import Version from "./Version.js";
 
 export default class ReplicateClient {
   baseURL;
@@ -21,8 +21,16 @@ export default class ReplicateClient {
     }
   }
 
-  version(id) {
-    return new Version({ id }, this);
+  model(fullId) {
+    const idComponents = /^([\w-]+)\/([\w-]+)@(\w+)$/.exec(fullId);
+
+    if (!idComponents) {
+      throw new ReplicateError(`Invalid ID: ${fullId}`);
+    }
+
+    const [, owner, name, version] = idComponents;
+
+    return new Model({ owner, name, version }, this);
   }
 
   prediction(id) {

--- a/lib/ReplicateClient.test.js
+++ b/lib/ReplicateClient.test.js
@@ -65,6 +65,61 @@ describe("constructor()", () => {
   });
 });
 
+describe("getModelVersions()", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(client, "request")
+      .mockResolvedValue([
+        { id: "testversion0" },
+        { id: "testversion1" },
+        { id: "testversion2" },
+        { id: "testversion3" },
+        { id: "testversion4" },
+      ]);
+  });
+
+  it("returns array of Models", async () => {
+    const models = await client.getModelVersions("test-owner/test-name");
+
+    expect(models).toBeInstanceOf(Array);
+    expect(models[0]).toBeInstanceOf(Model);
+  });
+
+  it("returns array of Models with version set", async () => {
+    const models = await client.getModelVersions("test-owner/test-name");
+
+    expect(models).toBeInstanceOf(Array);
+    expect(models[0]).toBeInstanceOf(Model);
+    expect(models[0].version).toBe("testversion0");
+  });
+
+  it("parses name string", async () => {
+    const models = await client.getModelVersions("test-owner/test-name");
+
+    expect(models[0].owner).toBe("test-owner");
+    expect(models[0].name).toBe("test-name");
+  });
+
+  it("handles complete params", async () => {
+    const models = await client.getModelVersions({
+      owner: "test-owner",
+      name: "test-name",
+    });
+
+    expect(models[0].owner).toBe("test-owner");
+    expect(models[0].name).toBe("test-name");
+  });
+
+  it("handles params with combined name", async () => {
+    const models = await client.getModelVersions({
+      name: "test-owner/test-name",
+    });
+
+    expect(models[0].owner).toBe("test-owner");
+    expect(models[0].name).toBe("test-name");
+  });
+});
+
 describe("model()", () => {
   it("returns Model", () => {
     const model = client.model("test-owner/test-name@testversion");

--- a/lib/ReplicateClient.test.js
+++ b/lib/ReplicateClient.test.js
@@ -11,6 +11,8 @@ import {
   ReplicateRequestError,
   ReplicateResponseError,
 } from "./errors.js";
+import Model from "./Model.js";
+import Prediction from "./Prediction.js";
 
 const { default: fetch } = await import("node-fetch");
 const { default: ReplicateClient } = await import("./ReplicateClient.js");
@@ -60,6 +62,22 @@ describe("constructor()", () => {
     delete process.env.REPLICATE_API_TOKEN;
 
     expect(() => new ReplicateClient({})).toThrowError(ReplicateError);
+  });
+});
+
+describe("model()", () => {
+  it("returns Model", () => {
+    const model = client.model("test-owner/test-name@testversion");
+
+    expect(model).toBeInstanceOf(Model);
+  });
+});
+
+describe("prediction()", () => {
+  it("returns Prediction", () => {
+    const prediction = client.prediction("testprediction");
+
+    expect(prediction).toBeInstanceOf(Prediction);
   });
 });
 

--- a/lib/ReplicateClient.test.js
+++ b/lib/ReplicateClient.test.js
@@ -71,6 +71,37 @@ describe("model()", () => {
 
     expect(model).toBeInstanceOf(Model);
   });
+
+  it("parses ID string", () => {
+    const model = client.model("test-owner/test-name@testversion");
+
+    expect(model.owner).toBe("test-owner");
+    expect(model.name).toBe("test-name");
+    expect(model.version).toBe("testversion");
+  });
+
+  it("handles complete params", () => {
+    const model = client.model({
+      owner: "test-owner",
+      name: "test-name",
+      version: "testversion",
+    });
+
+    expect(model.owner).toBe("test-owner");
+    expect(model.name).toBe("test-name");
+    expect(model.version).toBe("testversion");
+  });
+
+  it("handles params with combined name", () => {
+    const model = client.model({
+      name: "test-owner/test-name",
+      version: "testversion",
+    });
+
+    expect(model.owner).toBe("test-owner");
+    expect(model.name).toBe("test-name");
+    expect(model.version).toBe("testversion");
+  });
 });
 
 describe("prediction()", () => {

--- a/lib/ReplicateClient.test.js
+++ b/lib/ReplicateClient.test.js
@@ -70,12 +70,12 @@ describe("request()", () => {
     });
 
     await expect(
-      async () => await client.request("GET /v1/predictions/test-id")
+      async () => await client.request("GET /v1/predictions/testprediction")
     ).rejects.toThrowError(ReplicateRequestError);
     await expect(
-      async () => await client.request("GET /v1/predictions/test-id")
+      async () => await client.request("GET /v1/predictions/testprediction")
     ).rejects.toThrowError(
-      "Failed to make request: method=GET, url=https://api.replicate.com/v1/predictions/test-id, body=undefined"
+      "Failed to make request: method=GET, url=https://api.replicate.com/v1/predictions/testprediction, body=undefined"
     );
   });
 
@@ -89,12 +89,12 @@ describe("request()", () => {
     );
 
     await expect(
-      async () => await client.request("GET /v1/predictions/test-id")
+      async () => await client.request("GET /v1/predictions/testprediction")
     ).rejects.toThrowError(ReplicateResponseError);
     await expect(
-      async () => await client.request("GET /v1/predictions/test-id")
+      async () => await client.request("GET /v1/predictions/testprediction")
     ).rejects.toThrowError(
-      "403 Unauthorized for GET /v1/predictions/test-id: Something went wrong"
+      "403 Unauthorized for GET /v1/predictions/testprediction: Something went wrong"
     );
   });
 });

--- a/lib/ReplicateObject.js
+++ b/lib/ReplicateObject.js
@@ -1,6 +1,8 @@
 import { ReplicateError } from "./errors.js";
 
 export default class ReplicateObject {
+  static propertyMap = {};
+
   static fromJSON(json) {
     let props;
     try {
@@ -15,10 +17,7 @@ export default class ReplicateObject {
   client;
 
   constructor(props, client) {
-    for (const key in props) {
-      this[key] = props[key];
-    }
-
+    this.#setProps(props);
     this.client = client;
   }
 
@@ -26,9 +25,7 @@ export default class ReplicateObject {
     const action = this.actionForGet();
     const props = await this.client.request(action);
 
-    for (const key in props) {
-      this[key] = props[key];
-    }
+    this.#setProps(props);
 
     return this;
   }
@@ -39,5 +36,11 @@ export default class ReplicateObject {
 
   actionForGet() {
     throw new ReplicateError("Not implemented");
+  }
+
+  #setProps(props) {
+    for (const key in props) {
+      this[this.constructor.propertyMap[key] || key] = props[key];
+    }
   }
 }

--- a/lib/ReplicateObject.js
+++ b/lib/ReplicateObject.js
@@ -1,3 +1,4 @@
+import camelcaseKeys from "camelcase-keys";
 import { ReplicateError } from "./errors.js";
 
 export default class ReplicateObject {
@@ -39,8 +40,10 @@ export default class ReplicateObject {
   }
 
   #setProps(props) {
-    for (const key in props) {
-      this[this.constructor.propertyMap[key] || key] = props[key];
+    const camelcasedProps = camelcaseKeys(props);
+
+    for (const key in camelcasedProps) {
+      this[this.constructor.propertyMap[key] || key] = camelcasedProps[key];
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "camelcase-keys": "^8.0.2",
         "node-fetch": "^3.3.0"
       },
       "devDependencies": {
@@ -1320,6 +1321,45 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
+      "integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
+      "dependencies": {
+        "camelcase": "^7.0.0",
+        "map-obj": "^4.3.0",
+        "quick-lru": "^6.1.1",
+        "type-fest": "^2.13.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2753,6 +2793,17 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3075,6 +3126,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "REPLICATE_API_TOKEN=not-a-real-token node index.js && NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
+    "camelcase-keys": "^8.0.2",
     "node-fetch": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We specify a model by the pattern `owner/model@version`.

Conceptually, the model is the thing, not the version. The version is a way of specifying which version of the model we want, and doesn't make much sense in isolation (even if the API itself doesn't ask for the model (yet)).